### PR TITLE
update requirements.txt to match new buildout.cfg

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,6 +46,7 @@ six==1.9.0 #apt: 1.5.2
 ua-parser==0.3.3
 user-agents==0.1.1
 wsgiref==0.1.2
+django-ipware
 
 # apps go here
 -r tardis/apps/publication_forms/requirements.txt


### PR DESCRIPTION
django-ipware appears new to mydata branch but not included in requirements.txt so that build can work using pip install method
